### PR TITLE
Ajustes de timezone e melhorias de testes

### DIFF
--- a/agendador.py
+++ b/agendador.py
@@ -20,9 +20,9 @@ def encontrar_horarios_disponiveis(lista_ids_calendarios, data_inicio, data_fim,
     """
     # GARANTINDO QUE NOSSAS DATAS ESTÃO "CONSCIENTES" DO FUSO HORÁRIO UTC
     if data_inicio.tzinfo is None:
-        data_inicio = data_inicio.astimezone(timezone.utc)
+        data_inicio = data_inicio.replace(tzinfo=timezone.utc)
     if data_fim.tzinfo is None:
-        data_fim = data_fim.astimezone(timezone.utc)
+        data_fim = data_fim.replace(tzinfo=timezone.utc)
 
     # Montando a lista de agendas para a consulta
     items = [{"id": calendar_id} for calendar_id in lista_ids_calendarios]

--- a/encontra-agenda.py
+++ b/encontra-agenda.py
@@ -19,9 +19,9 @@ def encontrar_horarios_disponiveis(lista_ids_calendarios, data_inicio, data_fim,
     """
     # GARANTINDO QUE NOSSAS DATAS ESTÃO "CONSCIENTES" DO FUSO HORÁRIO UTC
     if data_inicio.tzinfo is None:
-        data_inicio = data_inicio.astimezone(timezone.utc)
+        data_inicio = data_inicio.replace(tzinfo=timezone.utc)
     if data_fim.tzinfo is None:
-        data_fim = data_fim.astimezone(timezone.utc)
+        data_fim = data_fim.replace(tzinfo=timezone.utc)
 
     # Montando a lista de agendas para a consulta
     items = [{"id": calendar_id} for calendar_id in lista_ids_calendarios]

--- a/teste_conexao.py
+++ b/teste_conexao.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
@@ -10,23 +11,23 @@ KEY_FILE_LOCATION = os.path.join(os.path.dirname(__file__), 'credentials.json')
 # Estamos dizendo que nosso robô quer acesso de leitura e escrita nos calendários.
 SCOPES = ['https://www.googleapis.com/auth/calendar']
 
-# 3. AUTENTICAÇÃO
-# Cria as credenciais do nosso robô a partir do arquivo JSON.
-creds = service_account.Credentials.from_service_account_file(
-        KEY_FILE_LOCATION, scopes=SCOPES)
 
-# 4. CONSTRUINDO O "CONTROLE REMOTO" DA API
-# Cria um objeto 'service' que sabe como "conversar" com a API do Google Agenda.
-service = build('calendar', 'v3', credentials=creds)
+def test_conexao():
+    """Verifica se a API do Google Agenda está acessível."""
+    if not os.path.exists(KEY_FILE_LOCATION):
+        pytest.skip("Arquivo de credenciais não encontrado.")
 
-print("Conexão bem-sucedida! Buscando agendas...")
+    try:
+        creds = service_account.Credentials.from_service_account_file(
+            KEY_FILE_LOCATION, scopes=SCOPES
+        )
+        service = build('calendar', 'v3', credentials=creds)
 
-# 5. EXECUTANDO A PRIMEIRA AÇÃO
-# Pede à API para listar todas as agendas na "lista de agendas" do nosso robô.
-calendar_list = service.calendarList().list().execute()
+        # 5. EXECUTANDO A PRIMEIRA AÇÃO
+        calendar_list = service.calendarList().list().execute()
 
-print("Agendas que o robô tem acesso:")
-# 6. MOSTRANDO O RESULTADO
-# Itera sobre a resposta e imprime o 'summary' (o nome) de cada agenda encontrada.
-for calendar_list_entry in calendar_list['items']:
-    print(f"- {calendar_list_entry['summary']}")
+        # 6. VERIFICANDO O RESULTADO
+        assert calendar_list.get('items'), "Lista de agendas vazia."
+    except Exception as e:
+        pytest.fail(f"Falha na autenticação ou conexão: {e}")
+

--- a/teste_escrita.py
+++ b/teste_escrita.py
@@ -22,12 +22,12 @@ if not calendar_id:
 # Criação de teste para evento daqui a 5 minutos
 now = datetime.now(timezone.utc)
 start_time = now + timedelta(minutes=5)
-end_time = start_time + timedelta(minutes=45) # Duração de 15 minutos
+end_time = start_time + timedelta(minutes=15) # Duração de 15 minutos
 
 # Definindo os detalhes do evento
 event = {
   'summary': 'Reunião de Alinhamento',
-  'description': 'EDiscutir próximos passos do projeto Robô Secretário',
+  'description': 'Discutir próximos passos do projeto Robô Secretário',
   'start': {
     'dateTime': start_time.isoformat(),  # O .isoformat() de um objeto 'aware' já contém o fuso horário
   },


### PR DESCRIPTION
## Summary
- corrige uso de `astimezone` em datas ingênuas
- ajusta descrição e duração do evento de teste
- transforma script de conexão em teste com assertiva e tratamento de erro

## Testing
- `pytest teste_conexao.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68bec1d79a7883318f34932f3ab41b4d